### PR TITLE
fixes session length not setting

### DIFF
--- a/e2e/timer.spec.ts
+++ b/e2e/timer.spec.ts
@@ -27,6 +27,16 @@ test.describe("Timer", () => {
     expect(sessionLength).toBe("24");
   });
 
+  test("adjusting session length then pressing start should change time", async ({
+    page,
+  }) => {
+    await page.click("#session-decrement");
+    await page.click("#start_stop");
+    await page.waitForTimeout(1000);
+    const time = await page.$eval("#time-left", (el) => el.textContent);
+    expect(time).toBe("23:59");
+  });
+
   test("session should increment by one", async ({ page }) => {
     await page.click("#session-increment");
     const sessionLength = await page.$eval(

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -40,6 +40,7 @@ function App() {
 
   const timerControl = () => {
     if (timerState === "stopped") {
+      setTimer(sessionLength * 60);
       startTimer();
       setTimerState("running");
     } else {


### PR DESCRIPTION
adjusting the session length would not have an effect on the timer when started.

closes #335 