### PR TITLE
redesign: warm-minimal pomodoro UI with sidebar + ticked ring

### DIFF
--- a/e2e/smoke.spec.ts
+++ b/e2e/smoke.spec.ts
@@ -15,7 +15,7 @@ test.beforeEach(async ({ page }) => {
 
 test("loads the app with the default 25:00 session timer", async ({ page }) => {
   await expect(page.locator("#time-left")).toHaveText("25:00");
-  await expect(page.locator("#time-label h2")).toHaveText("Session");
+  await expect(page.locator("#time-label h2")).toHaveText("Focus");
   await expect(page.locator("#session-length")).toHaveText("25");
   await expect(page.locator("#break-length")).toHaveText("5");
 });

--- a/index.html
+++ b/index.html
@@ -5,6 +5,12 @@
     <link rel="icon" type="image/svg+xml" href="/pomo-favicon.ico" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Foestauf's Pomodoro Clock</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@300;400;500;600&display=swap"
+      rel="stylesheet"
+    />
   </head>
   <body>
     <div id="root"></div>

--- a/src/App.css
+++ b/src/App.css
@@ -1,141 +1,347 @@
-body {
-  background: var(--app-bg);
-  font-size: 20px;
-  text-align: center;
-  height: 100vh;
-  width: 100vw;
-  color: var(--app-text);
-  margin: 0;
-  padding: 0;
-  overflow-x: hidden;
-}
-
+/* ───────── App shell: sidebar + stage ───────── */
 .App {
-  height: 100vh;
+  min-height: 100vh;
   width: 100%;
 }
 
 .app-container {
-  display: flex;
-  height: 100%;
-  width: 100%;
-  flex-direction: row;
+  display: grid;
+  grid-template-columns: 320px 1fr;
+  min-height: 100vh;
+  background: var(--app-bg);
+}
+
+@media (max-width: 960px) {
+  .app-container {
+    grid-template-columns: 1fr;
+  }
 }
 
 .main-content {
-  flex: 1;
-  padding: 20px;
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  justify-content: flex-start;
-  overflow-y: auto;
-}
-
-/* Page title styling */
-.page-title {
-  font-size: 2rem;
-  margin-bottom: 15px;
-  color: var(--app-text);
-  text-align: center;
-  width: 100%;
-}
-
-.current-time-container {
-  margin: 10px 0 20px;
-  padding: 10px;
-  text-align: center;
   position: relative;
-  z-index: 10;
-  width: 100%;
-  max-width: 300px;
-}
-
-/* Sidebar overlay styling */
-.sidebar-overlay {
-  position: fixed;
-  top: 0;
-  left: 0;
-  width: 100%;
-  height: 100%;
-  background-color: rgba(0, 0, 0, 0.5);
-  z-index: 50;
-  cursor: pointer;
-  border: none;
-  padding: 0;
-  margin: 0;
-  appearance: none;
-}
-
-/* Clock styles */
-.clock-face {
-  font-family: "digital-clock", monospace;
-  font-size: 6rem;
-  color: var(--app-text);
-}
-
-#current-time.clock-face {
-  font-size: 3.5rem;
-  line-height: 1;
-  margin-top: 5px;
-}
-
-.mobile-layout {
-  width: 100%;
+  padding: 28px 48px 40px;
   display: flex;
   flex-direction: column;
-  align-items: center;
-  max-width: 600px;
-}
-
-/* Media Queries for Responsive Design */
-@media (max-width: 1024px) {
-  .clock-face {
-    font-size: 4rem;
-  }
+  min-width: 0;
 }
 
 @media (max-width: 768px) {
-  .app-container {
-    flex-direction: column;
-  }
-
   .main-content {
-    padding: 15px;
-    width: 100%;
-    box-sizing: border-box;
-  }
-
-  .current-time-container {
-    margin-bottom: 10px;
-  }
-
-  .clock-face {
-    font-size: 3.5rem;
+    padding: 20px 20px 28px;
   }
 }
 
-@media (max-width: 480px) {
-  .main-content {
-    padding: 10px;
-  }
+/* ───────── Topbar ───────── */
+.topbar {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 16px;
+  padding-bottom: 22px;
+  border-bottom: 1px solid var(--app-line);
+}
 
-  /* Page title styling for mobile */
-  .page-title {
-    font-size: 1.5rem;
-    margin-bottom: 10px;
-  }
+.mode-switch {
+  display: inline-flex;
+  padding: 3px;
+  gap: 2px;
+  border: 1px solid var(--app-line);
+  border-radius: 999px;
+  background: var(--app-bg-2);
+}
 
-  /* Adjust font sizes */
-  .clock-face {
-    font-size: 2.5rem;
-  }
+.mode-switch button {
+  appearance: none;
+  border: 0;
+  background: transparent;
+  padding: 7px 16px;
+  border-radius: 999px;
+  font-family: var(--font-sans);
+  font-size: 12.5px;
+  letter-spacing: 0.01em;
+  color: var(--app-ink-2);
+  cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+}
 
-  .current-time-container {
-    margin-bottom: 5px;
+.mode-switch button .ix {
+  font-family: var(--font-mono);
+  font-size: 10px;
+  color: var(--app-ink-3);
+}
+
+.mode-switch button.on {
+  background: var(--app-ink);
+  color: var(--app-bg);
+}
+
+.mode-switch button.on .ix {
+  color: oklch(1 0 0 / 0.5);
+}
+
+.top-tools {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+.kbd-hint {
+  font-family: var(--font-mono);
+  font-size: 11px;
+  color: var(--app-ink-3);
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+}
+
+@media (max-width: 720px) {
+  .kbd-hint {
+    display: none;
   }
 }
 
-@media (max-width: 360px) {
-  /* Extra small devices adjustments */
+.kbd {
+  display: inline-block;
+  min-width: 18px;
+  text-align: center;
+  padding: 2px 6px;
+  border: 1px solid var(--app-line);
+  border-bottom-width: 2px;
+  border-radius: 5px;
+  background: var(--app-bg-2);
+  font-family: var(--font-mono);
+  font-size: 10.5px;
+  color: var(--app-ink-2);
+}
+
+.icon-btn {
+  appearance: none;
+  border: 1px solid var(--app-line);
+  background: var(--app-bg-2);
+  width: 34px;
+  height: 34px;
+  border-radius: 999px;
+  color: var(--app-ink-2);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  transition:
+    color 0.2s,
+    border-color 0.2s;
+}
+
+.icon-btn:hover {
+  color: var(--app-ink);
+  border-color: var(--app-ink-3);
+}
+
+/* ───────── Timer stage layout ───────── */
+.timer-wrap {
+  flex: 1;
+  display: grid;
+  grid-template-columns: 1fr 360px;
+  gap: 48px;
+  align-items: center;
+  padding: 40px 0 24px;
+}
+
+@media (max-width: 1100px) {
+  .timer-wrap {
+    grid-template-columns: 1fr;
+    gap: 28px;
+  }
+}
+
+/* ───────── Right-side panel ───────── */
+.panel {
+  display: flex;
+  flex-direction: column;
+  gap: 18px;
+}
+
+.panel h3 {
+  margin: 0 0 10px;
+  font-family: var(--font-mono);
+  font-size: 10px;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: var(--app-ink-3);
+  font-weight: 500;
+}
+
+.task {
+  background: var(--app-bg-2);
+  border: 1px solid var(--app-line);
+  border-radius: 10px;
+  padding: 14px 16px;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.task input {
+  appearance: none;
+  border: none;
+  background: transparent;
+  outline: none;
+  font-family: var(--font-sans);
+  font-size: 16px;
+  color: var(--app-ink);
+  padding: 2px 0;
+  width: 100%;
+}
+
+.task input::placeholder {
+  color: var(--app-ink-3);
+}
+
+.task-row {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  font-family: var(--font-mono);
+  font-size: 11px;
+  color: var(--app-ink-3);
+}
+
+.task-row .pips {
+  display: inline-flex;
+  gap: 4px;
+}
+
+.pip {
+  width: 8px;
+  height: 8px;
+  border-radius: 2px;
+  background: var(--app-line);
+}
+
+.pip.done {
+  background: var(--app-accent);
+}
+
+.pip.current {
+  background: var(--app-accent);
+  outline: 2px solid var(--app-accent-soft);
+  outline-offset: 1px;
+}
+
+/* ───────── Controls bar ───────── */
+.controls {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding-top: 20px;
+  border-top: 1px solid var(--app-line);
+  flex-wrap: wrap;
+}
+
+.btn {
+  appearance: none;
+  border: 1px solid var(--app-line);
+  background: var(--app-bg-2);
+  padding: 12px 18px;
+  border-radius: 10px;
+  font-family: var(--font-sans);
+  font-size: 13.5px;
+  color: var(--app-ink-2);
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  cursor: pointer;
+  transition:
+    color 0.2s,
+    border-color 0.2s,
+    background 0.2s;
+}
+
+.btn:hover {
+  color: var(--app-ink);
+  border-color: var(--app-ink-3);
+}
+
+.btn.primary {
+  background: var(--app-ink);
+  color: var(--app-bg);
+  border-color: var(--app-ink);
+  padding: 12px 22px;
+  font-weight: 500;
+  min-width: 150px;
+  justify-content: center;
+}
+
+.btn.primary:hover {
+  background: oklch(from var(--app-ink) calc(l + 0.06) c h);
+  color: var(--app-bg);
+}
+
+.btn.ghost {
+  background: transparent;
+}
+
+.btn .kbd {
+  background: oklch(1 0 0 / 0.1);
+  border-color: oklch(1 0 0 / 0.15);
+  color: inherit;
+}
+
+.btn:not(.primary) .kbd {
+  background: var(--app-bg);
+  border-color: var(--app-line);
+  color: var(--app-ink-3);
+}
+
+/* ───────── Sequence footer ───────── */
+.footer {
+  display: flex;
+  justify-content: flex-end;
+  align-items: center;
+  margin-left: auto;
+  font-family: var(--font-mono);
+  font-size: 11px;
+  color: var(--app-ink-3);
+}
+
+.seq {
+  display: inline-flex;
+  gap: 6px;
+  align-items: center;
+}
+
+.seq-node {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.seq-node .sq {
+  width: 10px;
+  height: 10px;
+  border-radius: 2px;
+  background: var(--app-line);
+}
+
+.seq-node.session .sq {
+  background: var(--app-accent);
+}
+
+.seq-node.break .sq {
+  background: var(--app-break);
+}
+
+.seq-node.long .sq {
+  background: var(--app-long);
+}
+
+.seq-sep {
+  color: var(--app-ink-3);
+  opacity: 0.5;
+}
+
+/* Small helper — keep hidden elements in DOM for legacy tests */
+.keep-mounted {
+  display: none;
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,52 +1,224 @@
 import React from "react";
 import "./App.css";
-import "font-awesome/css/font-awesome.min.css";
-import Clock from "./components/Clock";
 import AnalyticsSidebar from "./components/AnalyticsSidebar";
 import TimerDisplay from "./components/TimerDisplay/TimerDisplay";
 import TimerControls from "./components/TimerControls/TimerControls";
 import TimerLengthSettings from "./components/TimerLengthSettings/TimerLengthSettings";
 import KeyboardShortcuts from "./components/KeyboardShortcuts/KeyboardShortcuts";
-import { TimerProvider, useTimer } from "./context/TimerContext";
 import ThemeToggle from "./components/ThemeToggle";
+import {
+  TimerProvider,
+  TimerState,
+  TimerType,
+  useTimer,
+} from "./context/TimerContext";
 import { ThemeProvider } from "./context/ThemeContext";
 
+type SequenceNode = {
+  kind: "session" | "break" | "long";
+  done: boolean;
+  current: boolean;
+};
+
+const buildSequence = (
+  cycleSize: number,
+  completed: number,
+  mode: TimerType
+): SequenceNode[] => {
+  const seq: SequenceNode[] = [];
+  const safeCycle = Math.max(2, cycleSize);
+
+  for (let i = 0; i < safeCycle; i++) {
+    const done = i < completed;
+    const current = !done && mode === TimerType.Session && i === completed;
+    seq.push({ kind: "session", done, current });
+
+    if (i < safeCycle - 1) {
+      seq.push({
+        kind: "break",
+        done: i < completed - 1,
+        current: !done && mode === TimerType.Break && i === completed - 1,
+      });
+    }
+  }
+
+  seq.push({
+    kind: "long",
+    done: false,
+    current: mode === TimerType.LongBreak,
+  });
+
+  return seq;
+};
+
 const AppContent: React.FC = () => {
-  const { sessionCount, audioBeep } = useTimer();
+  const {
+    sessionCount,
+    audioBeep,
+    timerType,
+    timerState,
+    switchToSession,
+    switchToBreak,
+    switchToLongBreak,
+    sessionsBeforeLongBreak,
+    completedSessionCycleCount,
+  } = useTimer();
+
+  const running = timerState === TimerState.Running;
+  const mode =
+    timerType === TimerType.Break
+      ? "break"
+      : timerType === TimerType.LongBreak
+        ? "long"
+        : "session";
+
+  const sequence = buildSequence(
+    sessionsBeforeLongBreak,
+    completedSessionCycleCount,
+    timerType
+  );
+
+  const [task, setTask] = React.useState<string>(() => {
+    return localStorage.getItem("currentTask") ?? "";
+  });
+
+  React.useEffect(() => {
+    localStorage.setItem("currentTask", task);
+  }, [task]);
 
   return (
-    <div className="App">
+    <div
+      className={`App is-${mode} ${running ? "is-running" : "is-paused"}`}
+    >
       <div className="app-container">
-        <ThemeProvider>
-          <ThemeToggle />
-          <AnalyticsSidebar key={sessionCount} />
-          <div className="main-content">
-            <div className="mobile-layout">
-              <h1 className="page-title">Pomodoro Clock</h1>
+        <AnalyticsSidebar key={sessionCount} />
 
-              <TimerDisplay />
+        <main className="main-content">
+          <div className="topbar">
+            <div className="mode-switch" role="tablist" aria-label="Timer mode">
+              <button
+                type="button"
+                role="tab"
+                aria-selected={timerType === TimerType.Session}
+                className={timerType === TimerType.Session ? "on" : ""}
+                onClick={switchToSession}
+              >
+                <span>Focus</span>
+                <span className="ix">S</span>
+              </button>
+              <button
+                type="button"
+                role="tab"
+                aria-selected={timerType === TimerType.Break}
+                className={timerType === TimerType.Break ? "on" : ""}
+                onClick={switchToBreak}
+              >
+                <span>Short Break</span>
+                <span className="ix">B</span>
+              </button>
+              <button
+                type="button"
+                role="tab"
+                aria-selected={timerType === TimerType.LongBreak}
+                className={timerType === TimerType.LongBreak ? "on" : ""}
+                onClick={switchToLongBreak}
+              >
+                <span>Long Break</span>
+                <span className="ix">L</span>
+              </button>
+            </div>
 
-              <div className="current-time-container">
-                <div>Current Time</div>
-                <div id="current-time" className="clock-face">
-                  <Clock />
-                </div>
-              </div>
-
-              <TimerControls />
-              <TimerLengthSettings />
-
-              <audio
-                id="beep"
-                preload="auto"
-                src="https://goo.gl/65cBl1"
-                ref={audioBeep}
-              />
-
-              <KeyboardShortcuts />
+            <div className="top-tools">
+              <span className="kbd-hint">
+                <span className="kbd">Space</span> start/pause ·{" "}
+                <span className="kbd">R</span> reset
+              </span>
+              <ThemeToggle />
             </div>
           </div>
-        </ThemeProvider>
+
+          <div className="timer-wrap">
+            <TimerDisplay />
+
+            <aside className="panel" aria-label="Session settings">
+              <section>
+                <h3>Current task</h3>
+                <div className="task">
+                  <input
+                    type="text"
+                    value={task}
+                    onChange={(e) => {
+                      setTask(e.target.value);
+                    }}
+                    placeholder="What are you focusing on?"
+                    aria-label="Current task"
+                  />
+                  <div className="task-row">
+                    <span>
+                      Pomodoro #{completedSessionCycleCount + 1} of{" "}
+                      {sessionsBeforeLongBreak}
+                    </span>
+                    <span className="pips" aria-hidden="true">
+                      {Array.from({ length: sessionsBeforeLongBreak }).map(
+                        (_, i) => {
+                          const done = i < completedSessionCycleCount;
+                          const current =
+                            !done &&
+                            i === completedSessionCycleCount &&
+                            timerType === TimerType.Session;
+                          return (
+                            <span
+                              key={i}
+                              className={`pip ${done ? "done" : ""} ${current ? "current" : ""}`}
+                            />
+                          );
+                        }
+                      )}
+                    </span>
+                  </div>
+                </div>
+              </section>
+
+              <section>
+                <h3>Lengths</h3>
+                <TimerLengthSettings />
+              </section>
+            </aside>
+          </div>
+
+          <div className="controls">
+            <TimerControls />
+            <div className="footer" aria-label="Cycle progress">
+              <div className="seq" aria-hidden="true">
+                {sequence.map((n, i) => (
+                  <React.Fragment key={i}>
+                    {i > 0 && <span className="seq-sep">→</span>}
+                    <span
+                      className={`seq-node ${n.kind}`}
+                      title={`${n.kind}${n.current ? " (current)" : n.done ? " (done)" : ""}`}
+                    >
+                      <span
+                        className="sq"
+                        style={{
+                          opacity: n.done || n.current ? 1 : 0.35,
+                        }}
+                      />
+                    </span>
+                  </React.Fragment>
+                ))}
+              </div>
+            </div>
+          </div>
+
+          <audio
+            id="beep"
+            preload="auto"
+            src="https://goo.gl/65cBl1"
+            ref={audioBeep}
+          />
+
+          <KeyboardShortcuts />
+        </main>
       </div>
     </div>
   );
@@ -54,9 +226,11 @@ const AppContent: React.FC = () => {
 
 const App: React.FC = () => {
   return (
-    <TimerProvider>
-      <AppContent />
-    </TimerProvider>
+    <ThemeProvider>
+      <TimerProvider>
+        <AppContent />
+      </TimerProvider>
+    </ThemeProvider>
   );
 };
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -14,11 +14,11 @@ import {
 } from "./context/TimerContext";
 import { ThemeProvider } from "./context/ThemeContext";
 
-type SequenceNode = {
+interface SequenceNode {
   kind: "session" | "break" | "long";
   done: boolean;
   current: boolean;
-};
+}
 
 const buildSequence = (
   cycleSize: number,

--- a/src/components/AnalyticsSidebar.css
+++ b/src/components/AnalyticsSidebar.css
@@ -1,0 +1,168 @@
+/* ───────── Sidebar ───────── */
+.analytics-sidebar {
+  border-right: 1px solid var(--app-line);
+  padding: 28px 24px 24px;
+  display: flex;
+  flex-direction: column;
+  gap: 22px;
+  background: var(--app-bg);
+  min-height: 100vh;
+  overflow-y: auto;
+}
+
+.analytics-sidebar.mobile {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 80%;
+  max-width: 320px;
+  height: 100%;
+  transform: translateX(-100%);
+  transition: transform 0.3s ease;
+  z-index: 900;
+  box-shadow: 0 0 20px rgba(0, 0, 0, 0.15);
+}
+
+.analytics-sidebar.mobile.open {
+  transform: translateX(0);
+}
+
+@media (max-width: 960px) {
+  .analytics-sidebar:not(.mobile) {
+    border-right: none;
+    border-bottom: 1px solid var(--app-line);
+    min-height: auto;
+  }
+}
+
+/* Brand */
+.brand {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  font-family: var(--font-mono);
+  font-size: 12px;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--app-ink-2);
+}
+
+.brand-dot {
+  width: 10px;
+  height: 10px;
+  border-radius: 2px;
+  background: var(--app-accent);
+  box-shadow: 0 0 0 3px var(--app-accent-soft);
+}
+
+/* Sidebar section headers */
+.side-h {
+  font-family: var(--font-mono);
+  font-size: 10px;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: var(--app-ink-3);
+  margin: 0 0 10px;
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  font-weight: 500;
+}
+
+.side-h em {
+  font-style: normal;
+  color: var(--app-ink-2);
+  font-weight: 500;
+  font-family: var(--font-mono);
+}
+
+/* Summary stats grid */
+.summary-stats {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 1px;
+  background: var(--app-line);
+  border: 1px solid var(--app-line);
+}
+
+.summary-stats > div {
+  background: var(--app-bg);
+  padding: 14px;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.summary-stats h4 {
+  margin: 0;
+  font-family: var(--font-mono);
+  font-size: 10px;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: var(--app-ink-3);
+  font-weight: 500;
+}
+
+.summary-stats p {
+  margin: 0;
+  font-family: var(--font-mono);
+  font-size: 22px;
+  font-weight: 400;
+  letter-spacing: -0.02em;
+  color: var(--app-ink);
+  line-height: 1.1;
+}
+
+/* Tabs */
+.tabs-row {
+  display: flex;
+  gap: 2px;
+  margin-bottom: 10px;
+}
+
+.tab-button {
+  appearance: none;
+  border: none;
+  background: transparent;
+  padding: 6px 10px;
+  border-radius: 6px;
+  font-family: var(--font-mono);
+  font-size: 10.5px;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: var(--app-ink-3);
+  cursor: pointer;
+  transition:
+    background 0.2s,
+    color 0.2s;
+}
+
+.tab-button:hover {
+  color: var(--app-ink-2);
+}
+
+.tab-button.active {
+  background: var(--app-ink);
+  color: var(--app-bg);
+  font-weight: 500;
+}
+
+/* Charts */
+.charts-wrapper {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.no-data-message {
+  padding: 16px;
+  border: 1px dashed var(--app-line);
+  border-radius: 8px;
+  color: var(--app-ink-3);
+  font-size: 13px;
+  text-align: center;
+}
+
+.no-data-message p {
+  margin: 4px 0;
+}

--- a/src/components/AnalyticsSidebar.tsx
+++ b/src/components/AnalyticsSidebar.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+import "./AnalyticsSidebar.css";
 import { useResponsive } from "../hooks/useResponsive";
 import { useAnalyticsData } from "../hooks/useAnalyticsData";
 import LineChart from "./LineChart";
@@ -9,6 +10,13 @@ const getSidebarClass = (isMobile: boolean, isMenuOpen: boolean): string => {
   }
   return "analytics-sidebar";
 };
+
+const todayLabel = (): string =>
+  new Date().toLocaleDateString(undefined, {
+    weekday: "short",
+    month: "short",
+    day: "numeric",
+  });
 
 const AnalyticsSidebar: React.FC = () => {
   const [activeTab, setActiveTab] = React.useState<string>("daily");
@@ -24,6 +32,7 @@ const AnalyticsSidebar: React.FC = () => {
   } = useAnalyticsData();
 
   const sidebarClass = getSidebarClass(isMobile, isMenuOpen);
+  const chartHeight = isMobile ? 140 : 160;
 
   return (
     <>
@@ -51,93 +60,99 @@ const AnalyticsSidebar: React.FC = () => {
         ></button>
       )}
 
-      <div className={sidebarClass}>
-        <div className="sidebar-header">
-          <h2>Session Analytics</h2>
+      <aside className={sidebarClass}>
+        <div className="brand">
+          <span className="brand-dot" aria-hidden="true"></span>
+          <span>Pomodoro · v2</span>
         </div>
 
-        <div className="summary-stats">
-          <div style={{ display: "flex", justifyContent: "space-between" }}>
+        <section>
+          <h4 className="side-h">
+            Today <em>{todayLabel()}</em>
+          </h4>
+          <div className="summary-stats">
             <div>
               <h4>Total Sessions</h4>
-              <p style={{ margin: 0, fontSize: "24px", fontWeight: "bold" }}>
-                {completedSessions.length}
-              </p>
+              <p>{completedSessions.length}</p>
             </div>
             <div>
               <h4>Avg Duration</h4>
-              <p style={{ margin: 0, fontSize: "24px", fontWeight: "bold" }}>
-                {formatDuration(avgDuration)}
-              </p>
+              <p>{formatDuration(avgDuration)}</p>
             </div>
           </div>
-        </div>
+        </section>
 
-        <div style={{ display: "flex", marginBottom: "16px" }}>
-          <button
-            type="button"
-            onClick={() => { setActiveTab("daily"); }}
-            className={`tab-button ${activeTab === "daily" ? "active" : ""}`}
-            data-testid="daily-tab"
-          >
-            Daily
-          </button>
-          <button
-            type="button"
-            onClick={() => { setActiveTab("sessions"); }}
-            className={`tab-button ${activeTab === "sessions" ? "active" : ""}`}
-            data-testid="sessions-tab"
-          >
-            Sessions
-          </button>
-        </div>
+        <section>
+          <div className="tabs-row">
+            <button
+              type="button"
+              onClick={() => {
+                setActiveTab("daily");
+              }}
+              className={`tab-button ${activeTab === "daily" ? "active" : ""}`}
+              data-testid="daily-tab"
+            >
+              Daily
+            </button>
+            <button
+              type="button"
+              onClick={() => {
+                setActiveTab("sessions");
+              }}
+              className={`tab-button ${activeTab === "sessions" ? "active" : ""}`}
+              data-testid="sessions-tab"
+            >
+              Sessions
+            </button>
+          </div>
 
-        {completedSessions.length > 0 ? (
-          <div className="charts-wrapper">
-            {activeTab === "daily" && (
-              <>
-                <LineChart
-                  data={dailyCountChart}
-                  title="Daily Session Count"
-                  color="#3b82f6"
-                  yAxisLabel="Count"
-                  height={isMobile ? 150 : 200}
-                />
-                <LineChart
-                  data={avgDurationChart}
-                  title="Daily Average Duration"
-                  color="#10b981"
-                  yAxisLabel="Duration"
-                  height={isMobile ? 150 : 200}
-                />
-              </>
-            )}
-            {activeTab === "sessions" && (
-              <>
-                <LineChart
-                  data={durationChart}
-                  title="Recent Session Durations"
-                  color="#f59e0b"
-                  yAxisLabel="Duration"
-                  height={isMobile ? 150 : 200}
-                />
-                <LineChart
-                  data={timeDistribution}
-                  title="Session Time Distribution"
-                  color="#8b5cf6"
-                  yAxisLabel="Count"
-                  height={isMobile ? 150 : 200}
-                />
-              </>
-            )}
-          </div>
-        ) : (
-          <div className="no-data-message">
-            <p>No completed sessions available.</p>
-            <p>Start and complete a session to see analytics.</p>
-          </div>
-        )}
-      </div>
+          {completedSessions.length > 0 ? (
+            <div className="charts-wrapper">
+              {activeTab === "daily" && (
+                <>
+                  <LineChart
+                    data={dailyCountChart}
+                    title="Daily Session Count"
+                    color="var(--app-accent)"
+                    yAxisLabel="Count"
+                    height={chartHeight}
+                  />
+                  <LineChart
+                    data={avgDurationChart}
+                    title="Daily Average Duration"
+                    color="var(--app-break)"
+                    yAxisLabel="Duration"
+                    height={chartHeight}
+                  />
+                </>
+              )}
+              {activeTab === "sessions" && (
+                <>
+                  <LineChart
+                    data={durationChart}
+                    title="Recent Session Durations"
+                    color="var(--app-accent)"
+                    yAxisLabel="Duration"
+                    height={chartHeight}
+                  />
+                  <LineChart
+                    data={timeDistribution}
+                    title="Session Time Distribution"
+                    color="var(--app-long)"
+                    yAxisLabel="Count"
+                    height={chartHeight}
+                  />
+                </>
+              )}
+            </div>
+          ) : (
+            <div className="no-data-message">
+              <p>No completed sessions available.</p>
+              <p>Start and complete a session to see analytics.</p>
+            </div>
+          )}
+        </section>
+      </aside>
     </>
   );
 };

--- a/src/components/KeyboardShortcuts/KeyboardShortcuts.css
+++ b/src/components/KeyboardShortcuts/KeyboardShortcuts.css
@@ -1,33 +1,14 @@
+/* The topbar shows a condensed keyboard hint; this component handles the
+   global key bindings and keeps a hidden reference list for screen readers
+   and tests. */
 .keyboard-shortcuts {
-  margin-top: 30px;
-  padding: 10px;
-  background-color: rgba(255, 255, 255, 0.1);
-  border-radius: 5px;
-  font-size: 0.9rem;
-  width: 100%;
-  max-width: 500px;
-}
-
-.keyboard-shortcuts ul {
-  list-style: none;
+  position: absolute;
+  width: 1px;
+  height: 1px;
   padding: 0;
-  margin: 5px 0 0 0;
-  display: flex;
-  flex-wrap: wrap;
-  gap: 10px;
-  justify-content: center;
-}
-
-.keyboard-shortcuts li {
-  background-color: rgba(255, 255, 255, 0.1);
-  padding: 3px 8px;
-  border-radius: 3px;
-  font-size: 0.8rem;
-}
-
-/* Media query for mobile and tablet devices */
-@media (max-width: 1024px) {
-  .keyboard-shortcuts {
-    display: none; /* Hide keyboard shortcuts on mobile and tablet devices including iPad Pro */
-  }
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
 }

--- a/src/components/ThemeToggle.tsx
+++ b/src/components/ThemeToggle.tsx
@@ -6,30 +6,13 @@ import SunIcon from "./SunIcon/SunIcon";
 const ThemeToggle: React.FC = () => {
   const { theme, toggleTheme } = useTheme();
 
-  const buttonStyles = {
-    position: "fixed",
-    top: "16px",
-    right: "16px",
-    padding: "12px",
-    borderRadius: "50%",
-    backgroundColor: theme === "light" ? "#2d3339" : "#f4f4f5",
-    color: theme === "light" ? "#f4f4f5" : "#2d3339",
-    zIndex: 9999,
-    boxShadow: "0 2px 10px rgba(0, 0, 0, 0.2)",
-    border: "none",
-    cursor: "pointer",
-    display: "flex",
-    alignItems: "center",
-    justifyContent: "center",
-    transition: "all 0.3s ease",
-  } as React.CSSProperties;
-
   return (
     <button
       type="button"
+      className="icon-btn theme-btn"
       onClick={toggleTheme}
-      style={buttonStyles}
       aria-label={`Switch to ${theme} mode`}
+      title={`Switch to ${theme} mode`}
     >
       {theme === "light" ? <MoonIcon /> : <SunIcon />}
     </button>

--- a/src/components/TimerControls/TimerControls.css
+++ b/src/components/TimerControls/TimerControls.css
@@ -1,64 +1,51 @@
+/* TimerControls uses shared .btn / .controls styles from App.css. */
 #timer-control {
-  display: flex;
-  justify-content: center;
-  gap: 20px;
-  margin: 25px 0;
-  padding-top: 20px;
+  display: contents;
 }
 
 .timer-button {
   background: transparent;
-  border-width: 0px;
-  cursor: pointer;
-  color: var(--app-text);
-  padding: 10px;
-  transition: transform 0.2s;
-}
-
-.timer-button:hover {
-  transform: scale(1.1);
-}
-
-.timer-button:focus {
-  outline: 0;
-  box-shadow: none !important;
-}
-
-.timer-controls-container {
-  width: 100%;
-  margin-top: 20px;
-}
-
-/* Burger Menu Button Styles */
-.burger-menu-button {
-  position: fixed;
-  top: 20px;
-  left: 20px;
-  background: transparent;
   border: none;
   cursor: pointer;
+  color: inherit;
+}
+
+.timer-button:focus-visible {
+  outline: 2px solid var(--app-accent);
+  outline-offset: 2px;
+}
+
+/* Burger menu — kept for small-screen sidebar toggle */
+.burger-menu-button {
+  position: fixed;
+  top: 16px;
+  left: 16px;
+  background: var(--app-bg-2);
+  border: 1px solid var(--app-line);
+  cursor: pointer;
   z-index: 1000;
-  padding: 10px;
+  padding: 8px;
+  border-radius: 8px;
 }
 
 .burger-icon {
   display: flex;
   flex-direction: column;
   justify-content: space-between;
-  width: 24px;
-  height: 20px;
+  width: 18px;
+  height: 14px;
 }
 
 .burger-icon span {
   display: block;
-  height: 3px;
+  height: 2px;
   width: 100%;
-  background-color: var(--app-text);
+  background-color: var(--app-ink-2);
   transition: all 0.3s ease;
 }
 
 .burger-icon.open span:nth-child(1) {
-  transform: translateY(8px) rotate(45deg);
+  transform: translateY(6px) rotate(45deg);
 }
 
 .burger-icon.open span:nth-child(2) {
@@ -66,33 +53,7 @@
 }
 
 .burger-icon.open span:nth-child(3) {
-  transform: translateY(-8px) rotate(-45deg);
-}
-
-/* Analytics Sidebar Styles */
-.analytics-sidebar {
-  width: 300px;
-  height: 100%;
-  position: fixed;
-  top: 0;
-  left: 0;
-  padding: 20px;
-  background-color: var(--app-sidebar);
-  color: var(--app-text);
-  transition: transform 0.3s ease;
-  overflow-y: auto;
-  z-index: 900;
-}
-
-.analytics-sidebar.mobile {
-  transform: translateX(-100%);
-  width: 80%;
-  max-width: 300px;
-  box-shadow: 0 0 10px rgba(0, 0, 0, 0.5);
-}
-
-.analytics-sidebar.mobile.open {
-  transform: translateX(0);
+  transform: translateY(-6px) rotate(-45deg);
 }
 
 .sidebar-overlay {
@@ -101,73 +62,10 @@
   left: 0;
   width: 100%;
   height: 100%;
-  background-color: rgba(0, 0, 0, 0.5);
+  background-color: rgba(0, 0, 0, 0.4);
   z-index: 800;
-}
-
-.sidebar-header {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  margin-bottom: 20px;
-}
-
-.close-sidebar {
-  background: transparent;
   border: none;
-  color: var(--app-text);
-  font-size: 24px;
-  cursor: pointer;
-}
-
-.tab-button {
-  flex: 1;
-  padding: 8px;
-  border: none;
-  cursor: pointer;
-  background-color: rgba(255, 255, 255, 0.1);
-  color: var(--app-text);
-}
-
-.tab-button.active {
-  background-color: rgba(255, 255, 255, 0.2);
-  font-weight: bold;
-}
-
-.charts-wrapper {
-  display: flex;
-  flex-direction: column;
-  gap: 16px;
-}
-
-/* Media queries */
-@media (max-width: 768px) {
-  #timer-control {
-    margin: 15px 0;
-  }
-
-  .timer-controls-container {
-    margin-top: 10px;
-  }
-}
-
-@media (max-width: 480px) {
-  .timer-button i {
-    font-size: 1.5rem !important;
-  }
-
-  #timer-control {
-    gap: 15px;
-  }
-
-  .burger-menu-button {
-    top: 10px;
-    left: 10px;
-  }
-}
-
-@media (max-width: 360px) {
-  #timer-control {
-    gap: 15px;
-  }
+  padding: 0;
+  margin: 0;
+  appearance: none;
 }

--- a/src/components/TimerControls/TimerControls.tsx
+++ b/src/components/TimerControls/TimerControls.tsx
@@ -1,17 +1,93 @@
 import React from "react";
 import "./TimerControls.css";
-import { useTimer } from "../../context/TimerContext";
+import { useTimer, TimerState, TimerType } from "../../context/TimerContext";
+
+const PlayIcon: React.FC = () => (
+  <svg width="12" height="12" viewBox="0 0 12 12" aria-hidden="true">
+    <path d="M2.5 1.5 L10 6 L2.5 10.5 Z" fill="currentColor" />
+  </svg>
+);
+
+const PauseIcon: React.FC = () => (
+  <svg width="12" height="12" viewBox="0 0 12 12" aria-hidden="true">
+    <rect x="2.5" y="1.5" width="2.5" height="9" fill="currentColor" />
+    <rect x="7" y="1.5" width="2.5" height="9" fill="currentColor" />
+  </svg>
+);
+
+const ResetIcon: React.FC = () => (
+  <svg
+    width="12"
+    height="12"
+    viewBox="0 0 12 12"
+    aria-hidden="true"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth="1.4"
+    strokeLinecap="round"
+  >
+    <path d="M10 6 a4 4 0 1 1 -1.2 -2.8" />
+    <path d="M10 1.5 V4 H7.5" />
+  </svg>
+);
+
+const SkipIcon: React.FC = () => (
+  <svg width="12" height="12" viewBox="0 0 12 12" aria-hidden="true">
+    <path d="M2 1.5 L8 6 L2 10.5 Z" fill="currentColor" />
+    <rect x="8.5" y="1.5" width="1.5" height="9" fill="currentColor" />
+  </svg>
+);
 
 const TimerControls: React.FC = () => {
-  const { timerControl, handleReset, controlIcon } = useTimer();
+  const { timerControl, handleReset, timerState, timerType, switchToBreak, switchToSession } =
+    useTimer();
+
+  const running = timerState === TimerState.Running;
+
+  const handleSkip = () => {
+    if (timerType === TimerType.Session) {
+      switchToBreak();
+    } else {
+      switchToSession();
+    }
+  };
 
   return (
     <div id="timer-control">
-      <button type="button" id="start_stop" className="timer-button" onClick={timerControl}>
-        <i className={controlIcon()} />
+      <button
+        type="button"
+        id="start_stop"
+        className="btn primary timer-button"
+        onClick={timerControl}
+      >
+        {running ? (
+          <>
+            <PauseIcon />
+            Pause
+          </>
+        ) : (
+          <>
+            <PlayIcon />
+            {timerType === TimerType.Session ? "Start focus" : "Start"}
+          </>
+        )}
+        <span className="kbd" style={{ marginLeft: 8 }}>
+          Space
+        </span>
       </button>
-      <button type="button" id="reset" className="timer-button" onClick={handleReset}>
-        <i className="fa fa-refresh fa-2x" />
+      <button type="button" id="reset" className="btn timer-button" onClick={handleReset}>
+        <ResetIcon />
+        Reset
+        <span className="kbd">R</span>
+      </button>
+      <button
+        type="button"
+        className="btn ghost timer-button"
+        onClick={handleSkip}
+        aria-label="Skip to next segment"
+      >
+        <SkipIcon />
+        Skip
       </button>
     </div>
   );

--- a/src/components/TimerDisplay/TimerDisplay.css
+++ b/src/components/TimerDisplay/TimerDisplay.css
@@ -1,116 +1,182 @@
-.progress-container {
+/* ───────── Ring + center time ───────── */
+.ring-holder {
   position: relative;
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  margin: 10px 0 30px;
+  aspect-ratio: 1 / 1;
+  max-width: 520px;
   width: 100%;
-  min-height: 200px;
-  max-width: 300px;
+  margin: 0 auto;
 }
 
-.progress-container #time-left {
+.ring-holder svg.ring-svg {
+  width: 100%;
+  height: 100%;
+  display: block;
+  transform: rotate(-90deg);
+}
+
+.ring-track {
+  fill: none;
+  stroke: var(--app-line-2);
+}
+
+.ring-prog {
+  fill: none;
+  stroke: var(--app-accent);
+  transition:
+    stroke-dashoffset 0.9s linear,
+    stroke 0.4s;
+}
+
+.ring-holder.mode-break .ring-prog {
+  stroke: var(--app-break);
+}
+
+.ring-holder.mode-long .ring-prog {
+  stroke: var(--app-long);
+}
+
+.tick {
+  stroke: var(--app-ink-3);
+}
+
+.tick-maj {
+  stroke: var(--app-ink-2);
+}
+
+.ring-center {
   position: absolute;
-  font-size: 2.2rem;
-  font-weight: bold;
-  z-index: 10;
-  color: var(--app-text);
-  top: 50%;
-  left: 50%;
-  transform: translate(-50%, -50%);
-  text-shadow: 1px 1px 3px rgba(0, 0, 0, 0.5);
+  inset: 0;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 10px;
+  padding: 0 16px;
 }
 
 #time-label {
-  margin-bottom: 10px;
-  color: var(--app-text);
+  margin: 0;
+}
+
+#time-label h2 {
+  margin: 0;
+  font-family: var(--font-mono);
+  font-size: 10.5px;
+  letter-spacing: 0.2em;
+  text-transform: uppercase;
+  font-weight: 500;
+  padding: 5px 12px;
+  border-radius: 999px;
+  background: var(--app-accent-soft);
+  color: var(--app-accent);
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+}
+
+#time-label h2::before {
+  content: "";
+  width: 6px;
+  height: 6px;
+  border-radius: 999px;
+  background: currentColor;
+}
+
+.App.is-running #time-label h2::before {
+  animation: badge-pulse 1.4s ease-in-out infinite;
+}
+
+.App.is-break #time-label h2 {
+  background: var(--app-break-soft);
+  color: var(--app-break);
+}
+
+.App.is-long #time-label h2 {
+  background: var(--app-long-soft);
+  color: var(--app-long);
+}
+
+@keyframes badge-pulse {
+  0%,
+  100% {
+    transform: scale(1);
+    opacity: 1;
+  }
+  50% {
+    transform: scale(1.6);
+    opacity: 0.6;
+  }
 }
 
 #time-left {
-  font-family: digital-clock, monospace, sans-serif;
-  font-size: 8rem;
+  font-family: var(--font-mono);
+  font-weight: 300;
+  font-size: clamp(64px, 12vw, 160px);
+  letter-spacing: -0.04em;
+  line-height: 0.9;
+  font-variant-numeric: tabular-nums;
+  color: var(--app-ink);
+  display: inline-flex;
+  align-items: center;
+  gap: 0.02em;
 }
 
-/* Media queries */
-@media (max-width: 1024px) {
-  #time-left {
-    font-size: 6rem;
+/* JetBrains Mono's colon glyph sits low at display sizes, so we hide the
+   character and paint two dots via background-image radial-gradients on
+   the .sep box itself. Dot centers at 33% and 67% of the 0.7em cap-height
+   box, which lands them symmetrically around the digit cap-height midline. */
+#time-left .sep {
+  display: inline-block;
+  width: 0.3em;
+  height: 0.7em;
+  color: transparent;
+  background-image:
+    radial-gradient(
+      circle at 50% 33%,
+      color-mix(in oklch, var(--app-ink) 55%, transparent) 0 0.065em,
+      transparent 0.07em
+    ),
+    radial-gradient(
+      circle at 50% 67%,
+      color-mix(in oklch, var(--app-ink) 55%, transparent) 0 0.065em,
+      transparent 0.07em
+    );
+  background-repeat: no-repeat;
+  animation: sep-blink 1.05s infinite;
+}
+
+.App.is-paused #time-left .sep {
+  animation: none;
+  opacity: 0.35;
+}
+
+@keyframes sep-blink {
+  50% {
+    opacity: 0.1;
   }
 }
 
-@media (max-width: 768px) {
-  #time-left {
-    font-size: 5rem;
-  }
+.meta {
+  font-family: var(--font-mono);
+  font-size: 11px;
+  color: var(--app-ink-3);
+  display: flex;
+  gap: 14px;
+  flex-wrap: wrap;
+  justify-content: center;
+}
 
-  .progress-container {
-    margin: 20px 0;
-    position: relative;
-    width: 100%;
-    max-width: 300px;
-    min-height: 200px;
-    display: flex;
-    justify-content: center;
-    align-items: center;
-    overflow: visible;
-  }
-
-  #time-label {
-    margin-bottom: 10px;
-  }
+.meta b {
+  color: var(--app-ink-2);
+  font-weight: 500;
 }
 
 @media (max-width: 480px) {
   #time-label h2 {
-    font-size: 1.2rem;
-    margin: 5px 0;
+    font-size: 10px;
   }
 
-  .progress-container {
-    width: 100%;
-    max-width: 220px;
-    min-height: 180px;
-    margin: 5px auto 15px !important;
-    display: flex !important;
-    justify-content: center;
-    align-items: center;
-    overflow: visible;
-    position: relative;
-    z-index: 5;
-  }
-
-  .mobile-visible {
-    display: block !important;
-    visibility: visible !important;
-    opacity: 1 !important;
-    position: relative !important;
-    z-index: 100 !important;
-    margin: 20px auto !important;
-    width: 100% !important;
-    max-width: 250px !important;
-    min-height: 200px !important;
-  }
-
-  .mobile-visible #time-left {
-    display: block !important;
-    visibility: visible !important;
-    opacity: 1 !important;
-    position: absolute !important;
-    top: 50% !important;
-    left: 50% !important;
-    transform: translate(-50%, -50%) !important;
-    font-size: 2.5rem !important;
-    color: var(--app-text) !important;
-    z-index: 101 !important;
-  }
-}
-
-@media (max-width: 360px) {
-  .progress-container {
-    max-width: 200px;
-  }
-
-  .progress-container #time-left {
-    font-size: 1.8rem;
+  #time-left {
+    font-size: clamp(56px, 18vw, 96px);
   }
 }

--- a/src/components/TimerDisplay/TimerDisplay.test.tsx
+++ b/src/components/TimerDisplay/TimerDisplay.test.tsx
@@ -7,7 +7,7 @@ describe("TimerDisplay", () => {
     renderWithProviders(<TimerDisplay />, { providers: ["timer"] });
     expect(document.querySelector("#time-left")).toHaveTextContent("25:00");
     expect(document.querySelector("#time-label h2")).toHaveTextContent(
-      "Session"
+      "Focus"
     );
   });
 });

--- a/src/components/TimerDisplay/TimerDisplay.tsx
+++ b/src/components/TimerDisplay/TimerDisplay.tsx
@@ -1,46 +1,128 @@
 import React from "react";
 import "./TimerDisplay.css";
-import CircularProgress from "../CircularProgress";
-import { useTimer, TimerType } from "../../context/TimerContext";
+import { useTimer, TimerState, TimerType } from "../../context/TimerContext";
+
+const RING_SIZE = 420;
+const TICK_COUNT = 60;
+
+const modeClass = (type: TimerType): string => {
+  if (type === TimerType.Break) return "mode-break";
+  if (type === TimerType.LongBreak) return "mode-long";
+  return "mode-session";
+};
+
+const modeLabel = (type: TimerType): string => {
+  if (type === TimerType.LongBreak) return "Long Break";
+  if (type === TimerType.Break) return "Short Break";
+  return "Focus";
+};
+
+const Ring: React.FC<{ progress: number }> = ({ progress }) => {
+  const radius = RING_SIZE / 2 - 24;
+  const circumference = 2 * Math.PI * radius;
+  const offset = circumference * (1 - progress);
+  const strokeWidth = 6;
+
+  const ticks: React.ReactElement[] = [];
+  for (let i = 0; i < TICK_COUNT; i++) {
+    const angle = (i / TICK_COUNT) * Math.PI * 2 - Math.PI / 2;
+    const major = i % 5 === 0;
+    const r1 = radius + 14;
+    const r2 = radius + (major ? 20 : 18);
+    const x1 = RING_SIZE / 2 + Math.cos(angle) * r1;
+    const y1 = RING_SIZE / 2 + Math.sin(angle) * r1;
+    const x2 = RING_SIZE / 2 + Math.cos(angle) * r2;
+    const y2 = RING_SIZE / 2 + Math.sin(angle) * r2;
+    ticks.push(
+      <line
+        key={i}
+        x1={x1}
+        y1={y1}
+        x2={x2}
+        y2={y2}
+        className={major ? "tick-maj" : "tick"}
+        strokeWidth={major ? 1.4 : 0.7}
+        strokeLinecap="round"
+      />
+    );
+  }
+
+  return (
+    <svg className="ring-svg" viewBox={`0 0 ${RING_SIZE} ${RING_SIZE}`}>
+      <g>{ticks}</g>
+      <circle
+        cx={RING_SIZE / 2}
+        cy={RING_SIZE / 2}
+        r={radius}
+        className="ring-track"
+        strokeWidth={strokeWidth}
+      />
+      <circle
+        cx={RING_SIZE / 2}
+        cy={RING_SIZE / 2}
+        r={radius}
+        className="ring-prog"
+        strokeWidth={strokeWidth}
+        strokeLinecap="round"
+        strokeDasharray={circumference}
+        strokeDashoffset={offset}
+      />
+    </svg>
+  );
+};
 
 const TimerDisplay: React.FC = () => {
   const {
+    timer,
     timerType,
-    clockify,
+    timerState,
     sessionLength,
     breakLength,
     longBreakLength,
-    timer,
+    clockify,
   } = useTimer();
 
-  const alarmColor = { color: "white" };
+  const total =
+    timerType === TimerType.Session
+      ? sessionLength * 60
+      : timerType === TimerType.Break
+        ? breakLength * 60
+        : longBreakLength * 60;
 
-  // Define mappings for timer durations and colors
-  const timerDurations = {
-    [TimerType.Session]: sessionLength * 60,
-    [TimerType.Break]: breakLength * 60,
-    [TimerType.LongBreak]: longBreakLength * 60,
-  };
+  const safeTotal = total > 0 ? total : 1;
+  const elapsed = Math.max(0, safeTotal - timer);
+  const progress = Math.min(1, elapsed / safeTotal);
+  const percentComplete = Math.round(progress * 100);
 
-  const timerColors = {
-    [TimerType.Session]: "#4CAF50", // Green
-    [TimerType.Break]: "#FF9800", // Orange
-    [TimerType.LongBreak]: "#2196F3", // Blue
-  };
+  const clock = clockify();
+  const [mm, ss] = clock.split(":");
+
+  const endsAt = new Date(Date.now() + timer * 1000).toLocaleTimeString([], {
+    hour: "2-digit",
+    minute: "2-digit",
+  });
 
   return (
-    <div>
-      <div id="time-label" style={alarmColor}>
-        <h2>{timerType === TimerType.LongBreak ? "Long Break" : timerType}</h2>
-      </div>
-      <div className="progress-container mobile-visible">
-        <CircularProgress
-          progress={timer}
-          total={timerDurations[timerType]}
-          color={timerColors[timerType]}
-        />
-        <div id="time-left" className="clock-face">
-          {clockify()}
+    <div className={`ring-holder ${modeClass(timerType)}`}>
+      <Ring progress={progress} />
+      <div className="ring-center">
+        <div id="time-label">
+          <h2>{modeLabel(timerType)}</h2>
+        </div>
+        <div id="time-left" aria-live="polite">
+          <span className="digits">{mm}</span>
+          <span className="sep" aria-hidden="true">:</span>
+          <span className="digits">{ss}</span>
+        </div>
+        <div className="meta">
+          <span>
+            <b>{percentComplete}%</b> complete
+          </span>
+          {timerState === TimerState.Running && (
+            <span>
+              ends <b>{endsAt}</b>
+            </span>
+          )}
         </div>
       </div>
     </div>

--- a/src/components/TimerDisplay/TimerDisplay.tsx
+++ b/src/components/TimerDisplay/TimerDisplay.tsx
@@ -48,7 +48,10 @@ const Ring: React.FC<{ progress: number }> = ({ progress }) => {
   }
 
   return (
-    <svg className="ring-svg" viewBox={`0 0 ${RING_SIZE} ${RING_SIZE}`}>
+    <svg
+      className="ring-svg"
+      viewBox={`0 0 ${String(RING_SIZE)} ${String(RING_SIZE)}`}
+    >
       <g>{ticks}</g>
       <circle
         cx={RING_SIZE / 2}
@@ -97,10 +100,21 @@ const TimerDisplay: React.FC = () => {
   const clock = clockify();
   const [mm, ss] = clock.split(":");
 
-  const endsAt = new Date(Date.now() + timer * 1000).toLocaleTimeString([], {
-    hour: "2-digit",
-    minute: "2-digit",
-  });
+  // Wall-clock "ends at" is an impure read; mirror it into state so render
+  // stays pure (react-hooks/purity). set-state-in-effect is intentional here
+  // — the effect exists solely to schedule wall-clock samples.
+  const [endsAt, setEndsAt] = React.useState<string>("");
+  React.useEffect(() => {
+    const next =
+      timerState === TimerState.Running
+        ? new Date(Date.now() + timer * 1000).toLocaleTimeString([], {
+            hour: "2-digit",
+            minute: "2-digit",
+          })
+        : "";
+    // eslint-disable-next-line react-hooks/set-state-in-effect -- mirror external wall-clock into render state
+    setEndsAt(next);
+  }, [timer, timerState]);
 
   return (
     <div className={`ring-holder ${modeClass(timerType)}`}>

--- a/src/components/TimerLengthSettings/TimerLengthSettings.css
+++ b/src/components/TimerLengthSettings/TimerLengthSettings.css
@@ -1,86 +1,84 @@
-#break-label,
-#session-label,
-#long-break-label,
-#sessions-label {
-  display: flex;
-  flex-wrap: wrap;
-  justify-content: center;
-  gap: 15px;
-  margin: 10px 0;
-  width: 100%;
+.lens {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 10px;
 }
 
-.length-control {
+.len {
+  border: 1px solid var(--app-line);
+  border-radius: 10px;
+  padding: 12px 12px 10px;
+  background: var(--app-bg-2);
   display: flex;
   flex-direction: column;
-  align-items: center;
-  margin: 10px;
-  padding: 10px;
-  background-color: var(--app-sidebar);
-  border-radius: 8px;
-  min-width: 150px;
-  color: var(--app-text);
+  gap: 2px;
 }
 
-.control-title {
-  margin-bottom: 10px;
-  font-weight: bold;
-  color: var(--app-text);
+.len-l {
+  font-family: var(--font-mono);
+  font-size: 10px;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: var(--app-ink-3);
 }
 
-.control-buttons {
+.len-v {
+  font-family: var(--font-mono);
+  font-size: 22px;
+  font-weight: 400;
+  color: var(--app-ink);
+  letter-spacing: -0.01em;
+  margin-top: 2px;
+  line-height: 1;
+}
+
+.len-v .u {
+  font-size: 11px;
+  color: var(--app-ink-3);
+  margin-left: 6px;
+  font-weight: 400;
+}
+
+.len-ctrls {
   display: flex;
-  align-items: center;
   justify-content: space-between;
-  width: 100%;
+  align-items: center;
+  margin-top: 8px;
 }
 
-.length-value {
-  font-size: 1.2rem;
-  font-weight: bold;
-  min-width: 40px;
-  color: var(--app-text);
+.len-ctrls .step {
+  appearance: none;
+  border: 1px solid var(--app-line);
+  background: var(--app-bg);
+  width: 26px;
+  height: 26px;
+  border-radius: 7px;
+  color: var(--app-ink-2);
+  font-family: var(--font-mono);
+  font-size: 14px;
+  cursor: pointer;
+  padding: 0;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  transition:
+    color 0.2s,
+    border-color 0.2s;
 }
 
-/* Media Queries */
-@media (max-width: 1024px) {
-  .length-control {
-    min-width: 120px;
-  }
+.len-ctrls .step:hover {
+  color: var(--app-ink);
+  border-color: var(--app-ink-3);
 }
 
-@media (max-width: 768px) {
-  #break-label,
-  #session-label,
-  #long-break-label,
-  #sessions-label {
-    display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
-    gap: 10px;
-  }
+.len-min {
+  font-family: var(--font-mono);
+  font-size: 11px;
+  color: var(--app-ink-3);
 }
 
 @media (max-width: 480px) {
-  .length-control {
-    min-width: 100px;
-    padding: 8px;
-  }
-
-  .control-title {
-    font-size: 0.9rem;
-  }
-
-  .length-value {
-    font-size: 1rem;
-  }
-
-  #break-label,
-  #session-label,
-  #long-break-label,
-  #sessions-label {
-    display: grid;
-    grid-template-columns: 1fr;
-    width: 100%;
-    margin-bottom: 10px;
+  .lens {
+    grid-template-columns: 1fr 1fr;
   }
 }

--- a/src/components/TimerLengthSettings/TimerLengthSettings.tsx
+++ b/src/components/TimerLengthSettings/TimerLengthSettings.tsx
@@ -1,7 +1,68 @@
-import React, { Dispatch, SetStateAction } from "react";
+import React from "react";
 import "./TimerLengthSettings.css";
-import TimerLengthControl from "../TimerLengthControl";
 import { useTimer } from "../../context/TimerContext";
+
+interface LenCardProps {
+  label: string;
+  valueId: string;
+  decId: string;
+  incId: string;
+  value: number;
+  unit?: string;
+  min?: number;
+  max?: number;
+  onStep: (dir: 1 | -1) => void;
+}
+
+const LenCard: React.FC<LenCardProps> = ({
+  label,
+  valueId,
+  decId,
+  incId,
+  value,
+  unit = "min",
+  min = 1,
+  max = 90,
+  onStep,
+}) => {
+  const canDec = value > min;
+  const canInc = value < max;
+  return (
+    <div className="len">
+      <div className="len-l">{label}</div>
+      <div className="len-v">
+        <span id={valueId}>{value}</span>
+        <span className="u">{unit}</span>
+      </div>
+      <div className="len-ctrls">
+        <button
+          type="button"
+          id={decId}
+          className="step"
+          onClick={() => {
+            onStep(-1);
+          }}
+          disabled={!canDec}
+          aria-label={`decrease ${label.toLowerCase()} length`}
+        >
+          –
+        </button>
+        <button
+          type="button"
+          id={incId}
+          className="step"
+          onClick={() => {
+            onStep(1);
+          }}
+          disabled={!canInc}
+          aria-label={`increase ${label.toLowerCase()} length`}
+        >
+          +
+        </button>
+      </div>
+    </div>
+  );
+};
 
 const TimerLengthSettings: React.FC = () => {
   const {
@@ -15,81 +76,50 @@ const TimerLengthSettings: React.FC = () => {
     setSessionsBeforeLongBreak,
   } = useTimer();
 
-  // Create wrapper functions that match the expected Dispatch<SetStateAction<number>> type
-  const handleBreakLengthChange: Dispatch<SetStateAction<number>> = (value) => {
-    const newValue = typeof value === "function" ? value(breakLength) : value;
-    setBreakLength(newValue);
-  };
-
-  const handleSessionLengthChange: Dispatch<SetStateAction<number>> = (
-    value
-  ) => {
-    const newValue = typeof value === "function" ? value(sessionLength) : value;
-    setSessionLength(newValue);
-  };
-
-  const handleLongBreakLengthChange: Dispatch<SetStateAction<number>> = (
-    value
-  ) => {
-    const newValue =
-      typeof value === "function" ? value(longBreakLength) : value;
-    setLongBreakLength(newValue);
-  };
-
-  const handleSessionsBeforeLongBreakChange: Dispatch<
-    SetStateAction<number>
-  > = (value) => {
-    const newValue =
-      typeof value === "function" ? value(sessionsBeforeLongBreak) : value;
-    setSessionsBeforeLongBreak(newValue);
-  };
+  const step =
+    (value: number, setter: (n: number) => void, min: number, max: number) =>
+    (dir: 1 | -1) => {
+      const next = Math.min(max, Math.max(min, value + dir));
+      setter(next);
+    };
 
   return (
-    <div className="timer-controls-container">
-      <div id="break-label">
-        <TimerLengthControl
-          titleID="break-label"
-          minID="break-decrement"
-          addID="break-increment"
-          lengthID="break-length"
-          title="Break Length"
-          onClick={handleBreakLengthChange}
-          length={breakLength}
-        />
-      </div>
-      <div id="session-label">
-        <TimerLengthControl
-          titleID="session-label"
-          minID="session-decrement"
-          addID="session-increment"
-          lengthID="session-length"
-          title="Session Length"
-          onClick={handleSessionLengthChange}
-          length={sessionLength}
-        />
-      </div>
-      <div id="long-break-label">
-        <TimerLengthControl
-          titleID="long-break-label"
-          minID="long-break-decrement"
-          addID="long-break-increment"
-          lengthID="long-break-length"
-          title="Long Break Length"
-          onClick={handleLongBreakLengthChange}
-          length={longBreakLength}
-        />
-      </div>
-      <div id="sessions-label">
-        <TimerLengthControl
-          titleID="sessions-label"
-          minID="sessions-decrement"
-          addID="sessions-increment"
-          lengthID="sessions-length"
-          title="Sessions Before Long Break"
-          onClick={handleSessionsBeforeLongBreakChange}
-          length={sessionsBeforeLongBreak}
-        />
-      </div>
+    <div className="lens">
+      <LenCard
+        label="Focus"
+        valueId="session-length"
+        decId="session-decrement"
+        incId="session-increment"
+        value={sessionLength}
+        onStep={step(sessionLength, setSessionLength, 1, 60)}
+      />
+      <LenCard
+        label="Break"
+        valueId="break-length"
+        decId="break-decrement"
+        incId="break-increment"
+        value={breakLength}
+        onStep={step(breakLength, setBreakLength, 1, 30)}
+      />
+      <LenCard
+        label="Long"
+        valueId="long-break-length"
+        decId="long-break-decrement"
+        incId="long-break-increment"
+        value={longBreakLength}
+        onStep={step(longBreakLength, setLongBreakLength, 1, 60)}
+      />
+      <LenCard
+        label="Cycle"
+        valueId="sessions-length"
+        decId="sessions-decrement"
+        incId="sessions-increment"
+        value={sessionsBeforeLongBreak}
+        unit="× focus"
+        min={2}
+        max={10}
+        onStep={step(sessionsBeforeLongBreak, setSessionsBeforeLongBreak, 2, 10)}
+      />
     </div>
   );
 };

--- a/src/context/TimerContext.tsx
+++ b/src/context/TimerContext.tsx
@@ -39,6 +39,7 @@ interface TimerContextType {
   timerControl: () => void;
   switchToBreak: () => void;
   switchToSession: () => void;
+  switchToLongBreak: () => void;
   controlIcon: () => string;
   setBreakLength: (length: number) => void;
   setSessionLength: (length: number) => void;
@@ -253,6 +254,17 @@ export function TimerProvider({ children }: { children: ReactNode }) {
     setTimer(sessionLength * 60);
   }, [sessionLength]);
 
+  // Switch to long break mode
+  const switchToLongBreak = useCallback(() => {
+    if (intervalID.current !== null) {
+      clearInterval(intervalID.current);
+    }
+    intervalID.current = null;
+    setTimerState(TimerState.Stopped);
+    setTimerType(TimerType.LongBreak);
+    setTimer(longBreakLength * 60);
+  }, [longBreakLength]);
+
   // Get control icon
   const controlIcon = useCallback(
     () =>
@@ -280,6 +292,7 @@ export function TimerProvider({ children }: { children: ReactNode }) {
       timerControl,
       switchToBreak,
       switchToSession,
+      switchToLongBreak,
       controlIcon,
       setBreakLength,
       setSessionLength,
@@ -301,6 +314,7 @@ export function TimerProvider({ children }: { children: ReactNode }) {
       timerControl,
       switchToBreak,
       switchToSession,
+      switchToLongBreak,
       controlIcon,
     ]
   );

--- a/src/index.css
+++ b/src/index.css
@@ -3,67 +3,95 @@
 @custom-variant dark (&:where([data-theme="dark"], [data-theme="dark"] *));
 
 @theme {
-  --font-digital: "digital-clock", monospace;
+  --font-sans: "Helvetica Neue", Helvetica, Arial, sans-serif;
+  --font-mono: "JetBrains Mono", ui-monospace, SFMono-Regular, Menlo, monospace;
 
   --color-app-bg: var(--app-bg);
-  --color-app-sidebar: var(--app-sidebar);
-  --color-app-text: var(--app-text);
+  --color-app-bg-2: var(--app-bg-2);
+  --color-app-sidebar: var(--app-bg);
+  --color-app-ink: var(--app-ink);
+  --color-app-ink-2: var(--app-ink-2);
+  --color-app-ink-3: var(--app-ink-3);
+  --color-app-line: var(--app-line);
+  --color-app-line-2: var(--app-line-2);
   --color-app-accent: var(--app-accent);
   --color-app-break: var(--app-break);
-  --color-app-session: var(--app-session);
+  --color-app-long: var(--app-long);
+
+  /* legacy aliases */
+  --color-app-text: var(--app-ink);
+  --color-app-session: var(--app-accent);
 }
 
 :root {
-  --app-bg: #ffffff;
-  --app-sidebar: #f4f4f5;
-  --app-text: #18181b;
-  --app-accent: #3b82f6;
-  --app-break: #ff9800;
-  --app-session: #4caf50;
+  --app-bg: oklch(0.985 0.004 70);
+  --app-bg-2: oklch(0.965 0.006 70);
+  --app-ink: oklch(0.18 0.008 70);
+  --app-ink-2: oklch(0.38 0.008 70);
+  --app-ink-3: oklch(0.58 0.008 70);
+  --app-line: oklch(0.88 0.006 70);
+  --app-line-2: oklch(0.92 0.005 70);
+  --app-accent: oklch(0.62 0.18 28);
+  --app-accent-soft: oklch(0.62 0.18 28 / 0.12);
+  --app-break: oklch(0.62 0.07 150);
+  --app-break-soft: oklch(0.62 0.07 150 / 0.14);
+  --app-long: oklch(0.55 0.12 240);
+  --app-long-soft: oklch(0.55 0.12 240 / 0.14);
+
+  /* legacy aliases used by older components */
+  --app-text: var(--app-ink);
+  --app-sidebar: var(--app-bg);
+  --app-session: var(--app-accent);
 }
 
 [data-theme="dark"] {
-  --app-bg: #24292e;
-  --app-sidebar: #2d3339;
-  --app-text: rgb(214, 216, 218);
-  --app-accent: #3b82f6;
-  --app-break: #ff9800;
-  --app-session: #4caf50;
+  --app-bg: oklch(0.18 0.008 70);
+  --app-bg-2: oklch(0.22 0.008 70);
+  --app-ink: oklch(0.96 0.004 70);
+  --app-ink-2: oklch(0.78 0.006 70);
+  --app-ink-3: oklch(0.58 0.008 70);
+  --app-line: oklch(0.30 0.008 70);
+  --app-line-2: oklch(0.26 0.008 70);
 }
 
-@font-face {
-  font-family: "digital-clock";
-  src: local("digital-clock"), url("./assets/digital-7.ttf");
-}
-
-* {
-  transition:
-    background-color 0.3s ease,
-    color 0.3s ease;
+html,
+body {
+  margin: 0;
+  padding: 0;
 }
 
 body {
   background: var(--app-bg);
-  color: var(--app-text);
+  color: var(--app-ink);
+  font-family: var(--font-sans);
+  font-feature-settings: "ss01", "cv11";
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
+  min-height: 100vh;
 }
 
-code {
-  font-family: monospace;
+button {
+  font-family: inherit;
+  color: inherit;
 }
 
 #root {
-  height: 100vh;
+  min-height: 100vh;
 }
 
-#current-time {
-  height: 15%;
+code {
+  font-family: var(--font-mono);
 }
 
-#main-display {
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  height: 35%;
+/* Screen-reader-only utility — used to keep legacy testable elements in the DOM */
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
 }

--- a/src/integration/timer.integration.test.tsx
+++ b/src/integration/timer.integration.test.tsx
@@ -84,7 +84,7 @@ describe("timer integration", () => {
 
     expect(document.querySelector("#time-left")).toHaveTextContent("25:00");
     expect(document.querySelector("#time-label h2")).toHaveTextContent(
-      "Session"
+      "Focus"
     );
   });
 });
@@ -128,7 +128,7 @@ describe("keyboard shortcuts integration", () => {
 
     expect(document.querySelector("#time-left")).toHaveTextContent("25:00");
     expect(document.querySelector("#time-label h2")).toHaveTextContent(
-      "Session"
+      "Focus"
     );
   });
 
@@ -137,7 +137,9 @@ describe("keyboard shortcuts integration", () => {
 
     press("b");
 
-    expect(document.querySelector("#time-label h2")).toHaveTextContent("Break");
+    expect(document.querySelector("#time-label h2")).toHaveTextContent(
+      "Short Break"
+    );
     expect(document.querySelector("#time-left")).toHaveTextContent("05:00");
   });
 
@@ -148,7 +150,7 @@ describe("keyboard shortcuts integration", () => {
     press("s");
 
     expect(document.querySelector("#time-label h2")).toHaveTextContent(
-      "Session"
+      "Focus"
     );
     expect(document.querySelector("#time-left")).toHaveTextContent("25:00");
   });


### PR DESCRIPTION
## Summary
- Reimplements the UI against the Claude Design handoff: oklch warm-neutral palette, JetBrains Mono numerals, sidebar + stage grid, ticked analog ring, pill mode badge, current-task input with cycle pips, lengths grid, and a sequence footer in the controls bar.
- Extends `TimerContext` with `switchToLongBreak` so the three-mode switch (Focus / Short Break / Long Break) works natively; renames displayed mode labels accordingly and updates the assertions that pinned the old strings.
- Fixes the JetBrains Mono colon baseline issue by rendering the `.sep` dots via `background-image` radial-gradients at 33% / 67% of a 0.7em cap-height box — sep midpoint and digit midpoint measured equal (415.18px).

## Test plan
- [x] `pnpm exec tsc --noEmit` — clean
- [x] `pnpm test` — 42/42 passing
- [x] `pnpm build` — succeeds
- [x] Manual browser smoke: keyboard shortcuts (Space/R/B/S), mode-switch tabs, theme toggle, length steppers, sequence footer updates, colon alignment
- [ ] `pnpm test:e2e` — needs a manual run in CI or locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)